### PR TITLE
Fix typo

### DIFF
--- a/vignettes/PK_Example.Rmd
+++ b/vignettes/PK_Example.Rmd
@@ -569,7 +569,7 @@ ggplot(out.df.univariatecov.nca[out.df.univariatecov.nca$covname!="REF",], aes(
     quantiles      = c(0.05,0.5, 0.95)) +
   scale_x_continuous(
     breaks = c(0.25, 0.5, 0.8, 1/0.8, 1/0.5, 1/0.25),
-    tran   = "log") +
+    trans  = "log") +
   scale_fill_manual(
     name   = "Probability",
     values = c("white", "#0000FFA0", "#0000FFA0", "white"),


### PR DESCRIPTION
Hi Samer,

This PR fixes a typo that triggered a reverse dependency failure with the new version of ggplot2.


To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of Februari. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588.